### PR TITLE
Fix nav on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -238,3 +238,10 @@ only screen and (min-device-width: 768px) {
 .nrGrammardata a.icon + a.icon {
   margin-left: 0.75em;
 }
+
+@media handheld, (max-width: 1244px) {
+    .nrGrammardata nav {
+      right: 5px;
+      width: 8vw;
+    }
+}


### PR DESCRIPTION
On mobile devices the links on the right hand side overlap the text. I have added a media query that will resize these links if the device screen is too small.